### PR TITLE
Proper use of encoding for hashing international characters.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -61,7 +61,7 @@ module.exports = function(grunt) {
         },
         options: {
           keepExtension: true,
-          keepBasename: false 
+          keepBasename: false
         }
       },
       noBasenameOrExtension: {
@@ -70,7 +70,17 @@ module.exports = function(grunt) {
         },
         options: {
           keepExtension: false,
-          keepBasename: false 
+          keepBasename: false
+        }
+      },
+      internationalCharacters: {
+        files: {
+          'test/fixtures/output/internationalCharacters': 'test/fixtures/international.js'
+        },
+        options: {
+          encoding: 'utf8',
+          keepExtension: true,
+          keepBasename: true
         }
       },
       afterEach: {

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ grunt.initConfig({
         'dest/folder': 'src/file'
       },
       options: {
+        encoding: 'utf8',
         keepBasename: true,
         keepExtension: true,
         afterEach: function (fileChange) {

--- a/tasks/grunt-md5.js
+++ b/tasks/grunt-md5.js
@@ -21,7 +21,9 @@ module.exports = function(grunt) {
     var destDir;
     // file object : {newPath: /***/, oldPath: /***/, content: /***/}
     var currentFile;
-    var options = this.options();
+    var options = this.options({
+      encoding: 'utf8'
+    });
 
     grunt.verbose.writeflags(options, 'Options');
 
@@ -65,7 +67,7 @@ module.exports = function(grunt) {
           filename = basename +
             require('crypto').
             createHash('md5').
-            update(srcCode).
+            update(srcCode, options.encoding).
             digest('hex') + ext;
 
           destFile = path.join(file.dest, filename);

--- a/test/fixtures/international.js
+++ b/test/fixtures/international.js
@@ -1,0 +1,1 @@
+/* only for testing international characters: åäöæøéßç*/

--- a/test/md5_test.js
+++ b/test/md5_test.js
@@ -9,7 +9,7 @@ exports.md5 = {
 
     var md5Filename = 'test-' + require('crypto').
       createHash('md5').
-      update(grunt.file.read('test/fixtures/test.js')).
+      update(grunt.file.read('test/fixtures/test.js'), 'utf8').
       digest('hex') + '.js';
 
     test.ok(grunt.file.exists('test/fixtures/output/main/' + md5Filename),
@@ -21,7 +21,7 @@ exports.md5 = {
 
     var md5Filename = 'test-' + require('crypto').
       createHash('md5').
-      update(grunt.file.read('test/fixtures/test.js')).
+      update(grunt.file.read('test/fixtures/test.js'), 'utf8').
       digest('hex');
 
     test.ok(grunt.file.exists('test/fixtures/output/noExtension/' + md5Filename),
@@ -33,7 +33,7 @@ exports.md5 = {
 
     var md5Filename = require('crypto').
       createHash('md5').
-      update(grunt.file.read('test/fixtures/test.js')).
+      update(grunt.file.read('test/fixtures/test.js'), 'utf8').
       digest('hex') + '.js';
 
     test.ok(grunt.file.exists('test/fixtures/output/noBasename/' + md5Filename),
@@ -45,11 +45,24 @@ exports.md5 = {
 
     var md5Filename = require('crypto').
       createHash('md5').
-      update(grunt.file.read('test/fixtures/test.js')).
+      update(grunt.file.read('test/fixtures/test.js'), 'utf8').
       digest('hex');
 
     test.ok(grunt.file.exists('test/fixtures/output/noBasenameOrExtension/' + md5Filename),
             'should generate an MD5 filename without keeping its basename or extension');
+    test.done();
+  },
+  internationalCharacters: function(test) {
+    test.expect(1);
+
+    var md5Filename = 'international-' + require('crypto').
+      createHash('md5').
+      update(grunt.file.read('test/fixtures/international.js'), 'utf8').
+      digest('hex') + '.js';
+
+    test.ok(grunt.file.exists('test/fixtures/output/internationalCharacters/' + md5Filename),
+            'should generate correct MD5 filename for contents with international characters');
+
     test.done();
   },
   afterEach: function(test) {


### PR DESCRIPTION
The [documentation for hash.update()](http://nodejs.org/api/crypto.html#crypto_hash_update_data_input_encoding) states that if no encoding is given, the argument is expected to be a Buffer.

Like many other "hash tasks" for Grunt, grunt-md5 [provides the contents of the file as a string](https://github.com/jney/grunt-md5/blob/master/tasks/grunt-md5.js#L68) to `hash.update` without any encoding as a second argument, which is incorrect.

The result of this is an incorrect hash for files with international characters in them when no encoding is given to `hash.update`.

Setting the proper encoding when calling `hash.update` fixes this.
