### PR TITLE
Use encoding for reading source files

### DIFF
--- a/tasks/grunt-md5.js
+++ b/tasks/grunt-md5.js
@@ -52,7 +52,7 @@ module.exports = function(grunt) {
           var destFile;
           var ext = '';
           var filename;
-          var srcCode = grunt.file.read(srcFile);
+          var srcCode = grunt.file.read(srcFile, {encoding: options.encoding});
 
           // keep extension unless you explicitly tell to not
           if (options.keepExtension !== false) {

--- a/test/md5_test.js
+++ b/test/md5_test.js
@@ -9,7 +9,7 @@ exports.md5 = {
 
     var md5Filename = 'test-' + require('crypto').
       createHash('md5').
-      update(grunt.file.read('test/fixtures/test.js'), 'utf8').
+      update(grunt.file.read('test/fixtures/test.js', {encoding: 'utf8'}), 'utf8').
       digest('hex') + '.js';
 
     test.ok(grunt.file.exists('test/fixtures/output/main/' + md5Filename),
@@ -21,7 +21,7 @@ exports.md5 = {
 
     var md5Filename = 'test-' + require('crypto').
       createHash('md5').
-      update(grunt.file.read('test/fixtures/test.js'), 'utf8').
+      update(grunt.file.read('test/fixtures/test.js', {encoding: 'utf8'}), 'utf8').
       digest('hex');
 
     test.ok(grunt.file.exists('test/fixtures/output/noExtension/' + md5Filename),
@@ -33,7 +33,7 @@ exports.md5 = {
 
     var md5Filename = require('crypto').
       createHash('md5').
-      update(grunt.file.read('test/fixtures/test.js'), 'utf8').
+      update(grunt.file.read('test/fixtures/test.js', {encoding: 'utf8'}), 'utf8').
       digest('hex') + '.js';
 
     test.ok(grunt.file.exists('test/fixtures/output/noBasename/' + md5Filename),
@@ -45,7 +45,7 @@ exports.md5 = {
 
     var md5Filename = require('crypto').
       createHash('md5').
-      update(grunt.file.read('test/fixtures/test.js'), 'utf8').
+      update(grunt.file.read('test/fixtures/test.js', {encoding: 'utf8'}), 'utf8').
       digest('hex');
 
     test.ok(grunt.file.exists('test/fixtures/output/noBasenameOrExtension/' + md5Filename),
@@ -57,7 +57,7 @@ exports.md5 = {
 
     var md5Filename = 'international-' + require('crypto').
       createHash('md5').
-      update(grunt.file.read('test/fixtures/international.js'), 'utf8').
+      update(grunt.file.read('test/fixtures/international.js', {encoding: 'utf8'}), 'utf8').
       digest('hex') + '.js';
 
     test.ok(grunt.file.exists('test/fixtures/output/internationalCharacters/' + md5Filename),


### PR DESCRIPTION
Just hit me that the given encoding from #12 should be used for reading the file too.
