### PR TITLE
Context and options for callbacks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -128,6 +128,30 @@ module.exports = function(grunt) {
             });
           }
         }
+      },
+      contextAndOptionsAfterEach: {
+        files: {
+          'test/fixtures/output/contextAndOptions/': 'test/fixtures/test.js'
+        },
+        options: {
+          findMe: true,
+          afterEach: function(fileChange, options) {
+            var fileContent = 'options=' + typeof options + '\nfindMe=' + options.findMe + '\nthis.nameArgs=' + this.nameArgs;
+            fs.appendFileSync('test/fixtures/output/contextAndOptions/afterEach.out', fileContent);
+          }
+        }
+      },
+      contextAndOptionsAfter: {
+        files: {
+          'test/fixtures/output/contextAndOptions/': ['test/fixtures/test.js', 'test/fixtures/test2.js']
+        },
+        options: {
+          findMe: true,
+          after: function(fileChanges, options) {
+            var fileContent = 'options=' + typeof options + '\nfindMe=' + options.findMe + '\nthis.nameArgs=' + this.nameArgs;
+            fs.appendFileSync('test/fixtures/output/contextAndOptions/after.out', fileContent);
+          }
+        }
       }
     },
     nodeunit: {

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ grunt.initConfig({
         encoding: 'utf8',
         keepBasename: true,
         keepExtension: true,
-        afterEach: function (fileChange) {
+        afterEach: function (fileChange, options) {
           // Called once for each file processed by the md5 task.
 
           // fileChange is in following format:
@@ -39,12 +39,29 @@ grunt.initConfig({
           //
           // Where newPath is the path with MD5, oldPath is the original path,
           // and content is the file content.
+
+          // options is the options object of the task
+          // In this case:
+          // {encoding: 'utf8', keepBasename: true, keepExtension: true, afterEach: function () {...} after: function () {...}}
+
+          // The context (value of "this") is set to the context of the task
+          // this.nameArgs -> "md5:compile"
+          // See more information at http://gruntjs.com/api/inside-tasks
+
         },
-        after: function (fileChanges) {
+        after: function (fileChanges, options) {
           // Called after all of the files are processed by the md5 task.
 
           // fileChanges is an array, holding the same values are the afterEach callback.
           // [{newPath: '...', oldPath: '...', content: '...'}, ...]
+
+          // options is the options object of the task
+          // In this case:
+          // {encoding: 'utf8', keepBasename: true, keepExtension: true, afterEach: function () {...} after: function () {...}}
+
+          // The context (value of "this") is set to the context of the task
+          // this.nameArgs -> "md5:compile"
+          // See more information at http://gruntjs.com/api/inside-tasks
         }
       }
     }

--- a/tasks/grunt-md5.js
+++ b/tasks/grunt-md5.js
@@ -23,6 +23,8 @@ module.exports = function(grunt) {
     var options = this.options({
       encoding: 'utf8'
     });
+    
+    var context = this;
 
     grunt.verbose.writeflags(options, 'Options');
 
@@ -76,7 +78,7 @@ module.exports = function(grunt) {
 
           // for callback after each file
           if (_.isFunction(options.afterEach)) {
-            options.afterEach(currentFile);
+            options.afterEach.call(context, currentFile, options);
           }
 
           if (_.isFunction(options.after)) {
@@ -92,7 +94,7 @@ module.exports = function(grunt) {
 
       // call `after` if defined
       if (_.isFunction(options.after)) {
-        options.after(processedFiles);
+        options.after.call(context, processedFiles, options);
       }
     });
   });

--- a/test/expected/contextAndOptions/after.out
+++ b/test/expected/contextAndOptions/after.out
@@ -1,0 +1,3 @@
+options=object
+findMe=true
+this.nameArgs=md5:contextAndOptionsAfter

--- a/test/expected/contextAndOptions/afterEach.out
+++ b/test/expected/contextAndOptions/afterEach.out
@@ -1,0 +1,3 @@
+options=object
+findMe=true
+this.nameArgs=md5:contextAndOptionsAfterEach

--- a/test/md5_test.js
+++ b/test/md5_test.js
@@ -95,5 +95,19 @@ exports.md5 = {
     var expected = fs.readFileSync('test/expected/after.out', 'utf-8');
     test.equal(output, expected, 'should call after function with all new path, old path, and file content of all files');
     test.done();
+  },
+  contextAndOptionsAfterEach: function(test) {
+    test.expect(1);
+    var output = fs.readFileSync('test/fixtures/output/contextAndOptions/afterEach.out', 'utf-8');
+    var expected = fs.readFileSync('test/expected/contextAndOptions/afterEach.out', 'utf-8');
+    test.equal(output, expected, 'should give options to callback and set task context');
+    test.done();
+  },
+  contextAndOptionsAfter: function(test) {
+    test.expect(1);
+    var output = fs.readFileSync('test/fixtures/output/contextAndOptions/after.out', 'utf-8');
+    var expected = fs.readFileSync('test/expected/contextAndOptions/after.out', 'utf-8');
+    test.equal(output, expected, 'should give options to callback and set task context');
+    test.done();
   }
 };


### PR DESCRIPTION
I need to be able to refer to the options of the task in my after-callback to be able to keep my path declarations DRY.

This PR calls both the afterEach-callback and after-callback with the context of the task and also passes the options object to both callbacks.

The addition of the context is more of a "bonus". When writing a callback for grunt-md5 you typically write it in the Gruntfile.js. So naturally, when I wrote my first callback, I expected the context in my callback to be the same as the context for the task. But maybe this is just me. Passing the options object directly, without setting context, would be enough though. But I figured the task context couldn't hurt, unless people start doing `this.options()` inside their callbacks. But I think that is more of a documentation issue than code.

Hope I make sense :)
