### PR TITLE
After callback should only run once per task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -103,28 +103,76 @@ module.exports = function(grunt) {
         ]
       },
       afterEach: {
-        files: {
-          'test/fixtures/output/callback/': 'test/fixtures/test.js'
-        },
+        files: [
+          {
+            'test/fixtures/output/callback/': ['test/fixtures/test.js', 'test/fixtures/test2.js']
+          },
+          {
+            expand: true,
+            cwd: 'test/fixtures/expand/',
+            src: [
+              '*.js'
+            ],
+            dest: 'test/fixtures/output/callback/js/'
+          },
+          {
+            expand: true,
+            cwd: 'test/fixtures/expand/',
+            src: [
+              '*.css'
+            ],
+            dest: 'test/fixtures/output/callback/css/'
+          }
+        ],
         options: {
           afterEach: function(fileChange) {
-            var fileContent = 'newPath: ' + fileChange.newPath + '\noldPath: ' + fileChange.oldPath + '\ncontent: ' + fileChange.content;
+            var fileContent = [
+              'newPath:' + fileChange.newPath,
+              'oldPath:' + fileChange.oldPath,
+              'content:' + fileChange.content,
+              ''
+            ].join('\n');
             // Doing sync here because there isn't a way to do async in task execution.
             fs.appendFileSync('test/fixtures/output/afterEach.out', fileContent);
           }
         }
       },
       after: {
-        files: {
-          'test/fixtures/output/after/': ['test/fixtures/test.js', 'test/fixtures/test2.js']
-        },
+        files: [
+          {
+            'test/fixtures/output/after/': ['test/fixtures/test.js', 'test/fixtures/test2.js']
+          },
+          {
+            expand: true,
+            cwd: 'test/fixtures/expand/',
+            src: [
+              '*.js'
+            ],
+            dest: 'test/fixtures/output/after/js/'
+          },
+          {
+            expand: true,
+            cwd: 'test/fixtures/expand/',
+            src: [
+              '*.css'
+            ],
+            dest: 'test/fixtures/output/after/css/'
+          }
+        ],
         options: {
           after: function(fileChanges) {
+            var fileContent = '';
             fileChanges.forEach(function(fileChange) {
-              var fileContent = 'newPath: ' + fileChange.newPath + '\noldPath: ' + fileChange.oldPath + '\ncontent: ' + fileChange.content;
-              // Doing sync here because there isn't a way to do async in task execution.
-              fs.appendFileSync('test/fixtures/output/after.out', fileContent);
+              fileContent += [
+                'newPath:' + fileChange.newPath,
+                'oldPath:' + fileChange.oldPath,
+                'content:' + fileChange.content,
+                ''
+              ].join('\n');
             });
+            // Doing sync here because there isn't a way to do async in task execution.
+            // Do a writeFileSync instead of appendFileSync to help the tests ensure this after callback only runs once
+            fs.writeFileSync('test/fixtures/output/after.out', fileContent);
           }
         }
       },

--- a/tasks/grunt-md5.js
+++ b/tasks/grunt-md5.js
@@ -23,16 +23,16 @@ module.exports = function(grunt) {
     var options = this.options({
       encoding: null
     });
-    
+
     var context = this;
 
     grunt.verbose.writeflags(options, 'Options');
 
+    // Keep track of processedFiles so we can call the `after` callback if needed.
+    var processedFiles = [];
+
     this.files.forEach(function(filePair) {
       var isExpandedPair = filePair.orig.expand || false;
-
-      // Keep track of processedFiles so we can call the `after` callback if needed.
-      var processedFiles = [];
 
       if (typeof filePair.src === 'undefined') {
         grunt.fail.warn('Files object doesn\'t exist');
@@ -91,12 +91,12 @@ module.exports = function(grunt) {
           grunt.fail.warn('Fail to generate an MD5 file name');
         }
       });
-
-      // call `after` if defined
-      if (_.isFunction(options.after)) {
-        options.after.call(context, processedFiles, options);
-      }
     });
+
+    // call `after` if defined
+    if (_.isFunction(options.after)) {
+      options.after.call(context, processedFiles, options);
+    }
   });
 
   // From grunt-contrib-copy

--- a/test/expected/after.out
+++ b/test/expected/after.out
@@ -1,6 +1,20 @@
-newPath: test/fixtures/output/after/test-8ba6ae54067b2766661cd6f11331f557.js
-oldPath: test/fixtures/test.js
-content: /* only for testing */
-newPath: test/fixtures/output/after/test2-258ac5932af636e39d07ab7134de056a.js
-oldPath: test/fixtures/test2.js
-content: /* only for testing (test2.js) */
+newPath:test/fixtures/output/after/test-849e27d0aa28588b7679e0b2a84035f9.js
+oldPath:test/fixtures/test.js
+content:// Only for testing
+
+newPath:test/fixtures/output/after/test2-92b02606afa9aa2a8cd9fb8e11d29045.js
+oldPath:test/fixtures/test2.js
+content:// Only for testing (test2.js)
+
+newPath:test/fixtures/output/after/js/file1-d41d8cd98f00b204e9800998ecf8427e.js
+oldPath:test/fixtures/expand/file1.js
+content:
+newPath:test/fixtures/output/after/js/file2-d41d8cd98f00b204e9800998ecf8427e.js
+oldPath:test/fixtures/expand/file2.js
+content:
+newPath:test/fixtures/output/after/css/file3-d41d8cd98f00b204e9800998ecf8427e.css
+oldPath:test/fixtures/expand/file3.css
+content:
+newPath:test/fixtures/output/after/css/file4-d41d8cd98f00b204e9800998ecf8427e.css
+oldPath:test/fixtures/expand/file4.css
+content:

--- a/test/expected/afterEach.out
+++ b/test/expected/afterEach.out
@@ -1,3 +1,20 @@
-newPath: test/fixtures/output/callback/test-8ba6ae54067b2766661cd6f11331f557.js
-oldPath: test/fixtures/test.js
-content: /* only for testing */
+newPath:test/fixtures/output/callback/test-849e27d0aa28588b7679e0b2a84035f9.js
+oldPath:test/fixtures/test.js
+content:// Only for testing
+
+newPath:test/fixtures/output/callback/test2-92b02606afa9aa2a8cd9fb8e11d29045.js
+oldPath:test/fixtures/test2.js
+content:// Only for testing (test2.js)
+
+newPath:test/fixtures/output/callback/js/file1-d41d8cd98f00b204e9800998ecf8427e.js
+oldPath:test/fixtures/expand/file1.js
+content:
+newPath:test/fixtures/output/callback/js/file2-d41d8cd98f00b204e9800998ecf8427e.js
+oldPath:test/fixtures/expand/file2.js
+content:
+newPath:test/fixtures/output/callback/css/file3-d41d8cd98f00b204e9800998ecf8427e.css
+oldPath:test/fixtures/expand/file3.css
+content:
+newPath:test/fixtures/output/callback/css/file4-d41d8cd98f00b204e9800998ecf8427e.css
+oldPath:test/fixtures/expand/file4.css
+content:

--- a/test/fixtures/international.js
+++ b/test/fixtures/international.js
@@ -1,1 +1,1 @@
-/* only for testing international characters: åäöæøéßç*/
+// Only for testing international characters: åäöæøéßç

--- a/test/fixtures/test.js
+++ b/test/fixtures/test.js
@@ -1,1 +1,1 @@
-/* only for testing */
+// Only for testing

--- a/test/fixtures/test2.js
+++ b/test/fixtures/test2.js
@@ -1,1 +1,1 @@
-/* only for testing (test2.js) */
+// Only for testing (test2.js)

--- a/test/md5_test.js
+++ b/test/md5_test.js
@@ -3,8 +3,8 @@
 var grunt = require('grunt');
 var fs = require('fs');
 
-var test_md5 = '8ba6ae54067b2766661cd6f11331f557';
-var international_md5 = 'ae0e5baf6ea3a665d9bcf8f7266359ea';
+var test_md5 = '849e27d0aa28588b7679e0b2a84035f9';
+var international_md5 = 'ab23229dd625341559e2bde4c8a3dcfe';
 var grunt_logo_md5 = 'f44795fb5f6fb7a7eb432d71baeb2402';
 
 exports.md5 = {
@@ -49,7 +49,7 @@ exports.md5 = {
 
     var filePath = 'test/fixtures/output/expand/js/file1-d41d8cd98f00b204e9800998ecf8427e.js';
     test.ok(grunt.file.isFile(filePath), 'should generate js files not directories');
-    
+
     filePath = 'test/fixtures/output/expand/js/file2-d41d8cd98f00b204e9800998ecf8427e.js';
     test.ok(grunt.file.isFile(filePath), 'should generate js files not directories');
 
@@ -58,7 +58,7 @@ exports.md5 = {
 
     filePath = 'test/fixtures/output/expand/css/file4-d41d8cd98f00b204e9800998ecf8427e.css';
     test.ok(grunt.file.isFile(filePath), 'should generate css files not directories');
-    
+
     test.done();
   },
   afterEach: function(test) {
@@ -72,7 +72,7 @@ exports.md5 = {
     test.expect(1);
     var output = fs.readFileSync('test/fixtures/output/after.out', 'utf-8');
     var expected = fs.readFileSync('test/expected/after.out', 'utf-8');
-    test.equal(output, expected, 'should call after function with all new path, old path, and file content of all files');
+    test.equal(output, expected, 'should call after function _once_ with all new path, old path, and file content of all files');
     test.done();
   },
   contextAndOptionsAfterEach: function(test) {


### PR DESCRIPTION
I found that the `after` callback is run several times for each task, which is not what is expected and documented. It is run after every entry in `this.files` and it becomes apparent after #14 got merged.

This PR moves the invocation of the `after` callback to outside the loop of files and updates the Gruntfile.js and tests to try and make sure it is only run once.

PS. If #16 gets merged I can update this PR for an easier merge. EDIT: Done
